### PR TITLE
Add comprehensive test suite

### DIFF
--- a/telegram_interface.py
+++ b/telegram_interface.py
@@ -1,0 +1,20 @@
+from pitomadom import Pitomadom
+
+
+def process_update(update, bot=None):
+    """Handle a Telegram update by delegating to Pitomadom.
+
+    Parameters
+    ----------
+    update: object
+        An object with a ``message`` attribute containing ``text`` and
+        ``reply_text``.
+    bot: Pitomadom, optional
+        Bot instance used to generate a response. A new ``Pitomadom``
+        is created if none is provided.
+    """
+    bot = bot or Pitomadom()
+    text = getattr(getattr(update, 'message', None), 'text', '')
+    response = bot.interact(text)
+    update.message.reply_text(response)
+    return response

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# tests package

--- a/tests/test_curiosity.py
+++ b/tests/test_curiosity.py
@@ -1,0 +1,17 @@
+from curiosity import Curiosity
+
+
+def test_remember_inserts_row(tmp_path):
+    db_path = tmp_path / "test.db"
+    cur = Curiosity(str(db_path))
+    metrics = {"perplexity": 1.5, "entropy": 0.5, "resonance": 0.7}
+
+    cur.remember("user", "context", "response", metrics)
+
+    rows = cur.conn.execute(
+        "SELECT user_message, context, response, perplexity, entropy, "
+        "resonance FROM log"
+    ).fetchall()
+    assert rows == [
+        ("user", "context", "response", 1.5, 0.5, 0.7)
+    ]

--- a/tests/test_pitomadom.py
+++ b/tests/test_pitomadom.py
@@ -1,0 +1,18 @@
+from unittest.mock import Mock
+
+from pitomadom import Pitomadom
+
+
+def test_interact_flow():
+    bot = Pitomadom()
+
+    bot.subjectivity.reply = Mock(return_value="hello world")
+    bot.infinity.add = Mock()
+    bot.connections.related_tokens = Mock(return_value=["foo", "hello"])
+
+    result = bot.interact("hi")
+
+    bot.subjectivity.reply.assert_called_once_with("hi")
+    bot.infinity.add.assert_called_once_with("hello world")
+    bot.connections.related_tokens.assert_called_once_with("hello world")
+    assert result == "hello world foo."

--- a/tests/test_subjectivity.py
+++ b/tests/test_subjectivity.py
@@ -1,0 +1,18 @@
+import pytest
+import math
+
+from subjectivity import Subjectivity
+
+
+def test_metrics_entropy_perplexity():
+    text = "Hello hello world"
+    s = Subjectivity()
+    metrics = s._metrics(text)
+
+    freq = [2 / 3, 1 / 3]
+    expected_entropy = -sum(p * math.log(p, 2) for p in freq)
+    expected_perplexity = 2 ** expected_entropy
+
+    assert metrics["entropy"] == pytest.approx(expected_entropy)
+    assert metrics["perplexity"] == pytest.approx(expected_perplexity)
+    assert metrics["resonance"] == 1.0

--- a/tests/test_telegram_interface.py
+++ b/tests/test_telegram_interface.py
@@ -1,0 +1,17 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from telegram_interface import process_update
+
+
+def test_process_update_calls_bot_and_replies():
+    bot = Mock()
+    bot.interact.return_value = "pong"
+
+    message = Mock(text="ping")
+    update = SimpleNamespace(message=message)
+
+    process_update(update, bot)
+
+    bot.interact.assert_called_once_with("ping")
+    message.reply_text.assert_called_once_with("pong")


### PR DESCRIPTION
## Summary
- Add Telegram update handler for Pitomadom
- Test metrics computation, memory logging, interaction flow, and Telegram responses

## Testing
- `python -m flake8 tests telegram_interface.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8f9b993c08329bda860c7366107a5