### PR TITLE
Add .env example and token setup instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+TELEGRAM_TOKEN=your_bot_token_here

--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # subjectivity
+
+## Configuration
+
+Create a `.env` file with your Telegram bot token:
+
+```
+TELEGRAM_TOKEN=your_bot_token_here
+```
+
+You can obtain a token by creating a bot with [BotFather](https://t.me/BotFather) on Telegram.
+


### PR DESCRIPTION
## Summary
- add `.env.example` with placeholder Telegram token
- document how to supply token via BotFather in README

## Testing
- `pytest`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b8f973ada0832993841ea5c2b079de