### PR TITLE
Add Telegram interface and documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+TELEGRAM_TOKEN=your_token_here

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+worker: python tg.py

--- a/README.md
+++ b/README.md
@@ -1,1 +1,67 @@
 # subjectivity
+
+Subjectivity is a small experimental chatbot exploring context and language.
+
+It acts by combining objectivity, curiosity, and subjectivity modules.
+
+The Subjectivity class orchestrates responses from simple token-level features.
+
+Objectivity module fetches summaries from Wikipedia to ground the conversation.
+
+Curiosity module logs interactions in SQLite for memory and analysis.
+
+Together, these modules create a feedback loop between message and response.
+
+When a user message arrives, Subjectivity performs basic statistical metrics.
+
+It tokenizes the input and computes entropy, perplexity, and resonance.
+
+Charged tokens, like capitalized or long words, seed external searches.
+
+Objectivity fetches brief encyclopedic context for each charged token.
+
+This context is truncated to maintain a small byte footprint.
+
+The retrieved snippets supply neutral anchor points for the reply.
+
+Subjectivity then crafts a response by pairing words from the context.
+
+Duplicate pairs are removed to avoid repetitive phrasing.
+
+The final response is a blend of shuffled word pairs forming short sentences.
+
+Curiosity records the interaction, metrics, and context in a SQLite log.
+
+Stored logs allow later retrieval of related tokens via the Connections class.
+
+The design intentionally favors transparency over neural complexity.
+
+Each component is lightweight and CPU-friendly, enabling easy deployment.
+
+The Telegram interface wraps the core logic with a chat-friendly API.
+
+Incoming messages trigger the same analytical cycle before replies.
+
+The interface relies on long polling, keeping infrastructure minimal.
+
+A Procfile specifies how to run the bot in a container or platform.
+
+Environment variables provide the secret token for Telegram authorization.
+
+Requirements list dependencies so the environment can be replicated.
+
+Tests verify metric calculations and the construction of the Telegram app.
+
+Linting ensures the codebase remains clean and maintainable.
+
+The system invites experimentation by exposing internal state.
+
+Researchers can tweak the memory store to analyze conversational patterns.
+
+The simple design supports educational exploration of language modeling.
+
+Mathematically, entropy and perplexity estimate lexical uncertainty.
+
+Resonance measures the proportion of alphabetic tokens, hinting at structure.
+
+These metrics provide a quantitative glimpse into subjective language.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+python-telegram-bot>=20,<21
+requests>=2.0
+pytest
+flake8

--- a/tests/test_subjectivity.py
+++ b/tests/test_subjectivity.py
@@ -1,0 +1,29 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+import subjectivity  # noqa: E402
+
+
+def test_metrics():
+    s = subjectivity.Subjectivity()
+    metrics = s._metrics("Hello world hello")
+    assert set(metrics.keys()) == {"perplexity", "entropy", "resonance"}
+    assert metrics["perplexity"] >= 1
+    assert 0 <= metrics["resonance"] <= 1
+
+
+def test_reply(monkeypatch):
+    class DummyCuriosity:
+        def remember(self, *args, **kwargs):
+            pass
+
+    monkeypatch.setattr(subjectivity, "Curiosity", lambda: DummyCuriosity())
+    s = subjectivity.Subjectivity()
+
+    def dummy_context(message, tokens):
+        return "foo bar baz"
+
+    monkeypatch.setattr(s.objectivity, "context_window", dummy_context)
+    reply = s.reply("Hello world")
+    assert isinstance(reply, str) and len(reply) > 0

--- a/tests/test_tg.py
+++ b/tests/test_tg.py
@@ -1,0 +1,42 @@
+import types
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+import tg  # noqa: E402
+
+
+def test_build_application(monkeypatch):
+    class DummyApp:
+        def __init__(self):
+            self.handlers = []
+
+        def add_handler(self, h):
+            self.handlers.append(h)
+
+    class DummyBuilder:
+        def __init__(self):
+            self.token_value = None
+
+        def token(self, tok):
+            self.token_value = tok
+            return self
+
+        def build(self):
+            return DummyApp()
+
+    dummy_builder = DummyBuilder()
+    monkeypatch.setattr(tg, "ApplicationBuilder", lambda: dummy_builder)
+
+    class DummyHandler:
+        def __init__(self, filt, func):
+            self.filt = filt
+            self.func = func
+
+    monkeypatch.setattr(tg, "MessageHandler", DummyHandler)
+    monkeypatch.setattr(tg, "filters", types.SimpleNamespace(TEXT="TEXT"))
+
+    app = tg.build_application("TOKEN")
+    assert dummy_builder.token_value == "TOKEN"
+    assert isinstance(app, DummyApp)
+    assert len(app.handlers) == 1

--- a/tg.py
+++ b/tg.py
@@ -1,0 +1,27 @@
+import os
+from subjectivity import Subjectivity
+from telegram.ext import ApplicationBuilder, MessageHandler, filters
+
+
+def build_application(token: str):
+    """Builds a Telegram application bound to the Subjectivity chatbot."""
+    bot = Subjectivity()
+
+    async def handle(update, context):
+        text = update.message.text or ""
+        reply = bot.reply(text)
+        await update.message.reply_text(reply)
+
+    app = ApplicationBuilder().token(token).build()
+    app.add_handler(MessageHandler(filters.TEXT, handle))
+    return app
+
+
+def main():
+    token = os.environ["TELEGRAM_TOKEN"]
+    app = build_application(token)
+    app.run_polling()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement Telegram chat interface wrapping Subjectivity
- provide deployment files and dependency list
- expand README with detailed 33-paragraph description

## Testing
- `python -m flake8 tg.py tests/test_subjectivity.py tests/test_tg.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8f853a4148329a3ebea6357bf87d0