### PR TITLE
Optimize metrics computation with Counter and add invariance test

### DIFF
--- a/subjectivity.py
+++ b/subjectivity.py
@@ -2,7 +2,7 @@ import math
 import re
 import hashlib
 import random
-from collections import deque
+from collections import Counter, deque
 from typing import List, Tuple
 
 from objectivity import Objectivity
@@ -48,10 +48,11 @@ class Subjectivity:
     def _metrics(self, text: str):
         words = re.findall(r"\w+", text.lower())
         total = len(words) or 1
-        freq = {w: words.count(w) / total for w in set(words)}
+        counts = Counter(words)
+        freq = {w: c / total for w, c in counts.items()}
         entropy = -sum(p * math.log(p, 2) for p in freq.values())
         perplexity = 2 ** entropy
-        resonance = sum(1 for w in words if w.isalpha()) / total
+        resonance = sum(c for w, c in counts.items() if w.isalpha()) / total
         return {"perplexity": perplexity, "entropy": entropy, "resonance": resonance}
 
     def _charged_tokens(self, text: str) -> List[str]:

--- a/tests/test_subjectivity.py
+++ b/tests/test_subjectivity.py
@@ -1,5 +1,6 @@
 import pytest
 import math
+import re
 
 from subjectivity import Subjectivity
 
@@ -23,3 +24,27 @@ def test_pronoun_inversion_helpers():
     assert s._should_invert("You are fine") is True
     assert not s._should_invert("What are you doing")
     assert s._invert_pronouns_text("You are nice") == "I am nice"
+
+
+def _old_metrics(text: str):
+    words = re.findall(r"\w+", text.lower())
+    total = len(words) or 1
+    freq = {w: words.count(w) / total for w in set(words)}
+    entropy = -sum(p * math.log(p, 2) for p in freq.values())
+    perplexity = 2 ** entropy
+    resonance = sum(1 for w in words if w.isalpha()) / total
+    return {"perplexity": perplexity, "entropy": entropy, "resonance": resonance}
+
+
+def test_metrics_invariance():
+    s = Subjectivity()
+    texts = [
+        "Hello hello world 123",
+        "Numbers 1 2 3 and letters abc ABC",
+    ]
+    for text in texts:
+        metrics = s._metrics(text)
+        expected = _old_metrics(text)
+        assert metrics["entropy"] == pytest.approx(expected["entropy"])
+        assert metrics["perplexity"] == pytest.approx(expected["perplexity"])
+        assert metrics["resonance"] == pytest.approx(expected["resonance"])


### PR DESCRIPTION
## Summary
- speed up metrics calculation by using `collections.Counter`
- derive frequencies and resonance directly from counter values
- add regression test ensuring metrics stay unchanged

## Testing
- `python -m flake8` (fails: style violations)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9fd4200c88329a8630aa2ad7ead94