### PR TITLE
Use Counter in metrics and expand invariance tests

### DIFF
--- a/subjectivity.py
+++ b/subjectivity.py
@@ -49,8 +49,7 @@ class Subjectivity:
         words = re.findall(r"\w+", text.lower())
         total = len(words) or 1
         counts = Counter(words)
-        freq = {w: c / total for w, c in counts.items()}
-        entropy = -sum(p * math.log(p, 2) for p in freq.values())
+        entropy = -sum((c / total) * math.log(c / total, 2) for c in counts.values())
         perplexity = 2 ** entropy
         resonance = sum(c for w, c in counts.items() if w.isalpha()) / total
         return {"perplexity": perplexity, "entropy": entropy, "resonance": resonance}
@@ -96,7 +95,6 @@ class Subjectivity:
         rng = random.Random(seed)
         orig = message
         words = re.findall(r"\b\w+\b", orig)
-        lower = [w.lower() for w in words]
 
         # преференция инвертированных местоимений (как в me.Engine._invert_pronouns)
         pref = [ _PRONOUN_MAP.get(w, w) for w in [w.lower() for w in words] ]

--- a/tests/test_subjectivity.py
+++ b/tests/test_subjectivity.py
@@ -36,15 +36,19 @@ def _old_metrics(text: str):
     return {"perplexity": perplexity, "entropy": entropy, "resonance": resonance}
 
 
-def test_metrics_invariance():
-    s = Subjectivity()
-    texts = [
+@pytest.mark.parametrize(
+    "text",
+    [
         "Hello hello world 123",
         "Numbers 1 2 3 and letters abc ABC",
-    ]
-    for text in texts:
-        metrics = s._metrics(text)
-        expected = _old_metrics(text)
-        assert metrics["entropy"] == pytest.approx(expected["entropy"])
-        assert metrics["perplexity"] == pytest.approx(expected["perplexity"])
-        assert metrics["resonance"] == pytest.approx(expected["resonance"])
+        "",
+        "Repeat repeat repeat word",
+    ],
+)
+def test_metrics_invariance(text):
+    s = Subjectivity()
+    metrics = s._metrics(text)
+    expected = _old_metrics(text)
+    assert metrics["entropy"] == pytest.approx(expected["entropy"])
+    assert metrics["perplexity"] == pytest.approx(expected["perplexity"])
+    assert metrics["resonance"] == pytest.approx(expected["resonance"])


### PR DESCRIPTION
## Summary
- Optimize `_metrics` to compute frequency metrics directly from `Counter`
- Parameterize subjectivity tests to confirm metrics remain unchanged after optimization

## Testing
- `ruff check subjectivity.py tests/test_subjectivity.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9fe7e78cc8329b0980d95e04678c8