### PR TITLE
Filter ignored tokens from queries and snippets

### DIFF
--- a/objectivity.py
+++ b/objectivity.py
@@ -189,12 +189,23 @@ class Objectivity:
         NO Wikipedia. NO definitions. NO glossary content.
         """
         conversational_snippets: List[str] = []
-        
+
+        # Prepare ignored tokens set
+        ignored = {t.lower() for t in _tokens_ignored}
+
+        # Remove ignored tokens from the message before building queries
+        if ignored:
+            pattern = r"\b(?:" + "|".join(re.escape(t) for t in ignored) + r")\b"
+            message = re.sub(pattern, "", message, flags=re.IGNORECASE)
+
+        message = re.sub(r"\s+", " ", message).strip()
+        if not message:
+            return ""
+
         # Build conversation-focused queries
         queries = _build_conversation_queries(message)
 
         # Filter out queries containing any ignored tokens
-        ignored = {t.lower() for t in _tokens_ignored}
         queries = [
             q for q in queries
             if not any(token in q.lower() for token in ignored)
@@ -207,8 +218,10 @@ class Objectivity:
             try:
                 snippets = _ddg_json(query)
                 for snippet in snippets:
+                    if any(token in snippet.lower() for token in ignored):
+                        continue
                     # Double-check it's conversational
-                    if (_looks_conversational(snippet) and 
+                    if (_looks_conversational(snippet) and
                         not _looks_like_glossary(snippet) and
                         len(snippet.split()) >= 4):  # Minimum substance
                         

--- a/tests/test_objectivity.py
+++ b/tests/test_objectivity.py
@@ -12,7 +12,7 @@ def test_ignored_tokens_not_in_queries(monkeypatch):
     monkeypatch.setattr(objectivity, "_ddg_json", fake_ddg_json)
 
     obj = Objectivity()
-    obj.context_window("talk about banana", ["banana"])
+    obj.context_window("banana", ["banana"])
 
     assert sent_queries == []
 
@@ -31,4 +31,39 @@ def test_mixed_queries_filter(monkeypatch):
 
     assert sent_queries  # other queries should remain
     assert all("responding" not in q for q in sent_queries)
+
+
+def test_filtered_tokens_removed_before_query_building(monkeypatch):
+    sent_queries = []
+
+    def fake_ddg_json(query):
+        sent_queries.append(query)
+        return []
+
+    monkeypatch.setattr(objectivity, "_ddg_json", fake_ddg_json)
+
+    obj = Objectivity()
+    obj.context_window("talk about banana", ["banana"])
+
+    assert sent_queries
+    assert all("banana" not in q.lower() for q in sent_queries)
+
+
+def test_snippets_skip_ignored_tokens(monkeypatch):
+    monkeypatch.setattr(
+        objectivity,
+        "_build_conversation_queries",
+        lambda message: ["dummy"],
+    )
+
+    def fake_ddg_json(query):
+        return ["banana is great", "I think we should talk"]
+
+    monkeypatch.setattr(objectivity, "_ddg_json", fake_ddg_json)
+
+    obj = Objectivity()
+    result = obj.context_window("any message", ["banana"])
+
+    assert "banana" not in result.lower()
+    assert "i think we should talk" in result.lower()
 


### PR DESCRIPTION
## Summary
- Remove ignored tokens from input before constructing conversation queries
- Skip snippets containing ignored tokens and expand tests for filtering logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba10759d0483299dac7617f4fcfb20